### PR TITLE
Allow anonymous calls to create/pay order

### DIFF
--- a/definitions/finance/payment_request.yaml
+++ b/definitions/finance/payment_request.yaml
@@ -6,6 +6,10 @@ properties:
   redirect_url:
     type: string
     description: url to redirect to after paying
+  subscription_msisdn:
+    type: string
+    description: >
+      Msisdn of the subscription the order to be paid belongs to.  Required if the operation is invoked anonymously.
   invoice_id:
     type: string
     description: ID of the invoice to pay.  Pass either this or order_id.

--- a/definitions/orders/create_order.yaml
+++ b/definitions/orders/create_order.yaml
@@ -10,12 +10,17 @@ properties:
     type: array
     description: >
       E.g. when you migrate between subscription types like going from postpaid subscription to prepaid product.
-      You order a prepaid subscription and additionally you can add a topup just like if you were creating a prepaid subscription.
+      You order a prepaid subscription and additionally you can add a topup just like if you were creating a prepaid
+      subscription.
     items:
       $ref: '#/definitions/ProductId'
   subscription_id:
     type: string
     description: The ID of the subscription that this order is for
+  subscription_msisdn:
+    type: string
+    description: >
+      The MSISDN of the subscription that this order is for.  Required if this operation is invoked anonymously.
   password:
     type: string
     description: A password is required for performing migrations from prepaid to postpaid.

--- a/paths/orders/create_and_list.yaml
+++ b/paths/orders/create_and_list.yaml
@@ -3,15 +3,18 @@ post:
     - Orders
   summary: Create order
   description: |
-    This end point is used to order the products in the catalog.
+    This end point is used to order the products in the catalog.  Depending on the product chosen, this can amount to
+    a topup, a bundle activation, a product migration, ...
 
     For our mobile brands:
 
     To migrate a subscription from postpaid to prepaid you need to specify a product, which corresponds with
     that subscription, and a topup. The topup can be specified using a child product.
 
-
     A migration from prepaid to postpaid just requires you to specify the product id of the chosen postpaid subscription.
+
+    All orders require authentication, except for creating topups.  However if the latter is done anonymously, the
+    subcriber_msisdn field is required.
   consumes:
   - application/json
   produces:


### PR DESCRIPTION
Here's a first attempt at the interface anonymous topup (aka topup-for-a-friend) for uwa.

The goal is to allow anyone to top up for another user, as long as he pays for that topup.

Let's not discuss how we can/cannot implement this here, but just focus on whether the interface makes sense this way.

