### PR TITLE
Add credit notes type to invoices

### DIFF
--- a/definitions/finance/invoice.yaml
+++ b/definitions/finance/invoice.yaml
@@ -7,6 +7,7 @@ required:
   - amount
   - status
   - amount_due
+  - type
 properties:
   id:
     type: string
@@ -36,3 +37,11 @@ properties:
   amount_due:
     type: number
     format: float
+  type:
+    type: string
+    enum:
+      - invoice
+      - credit_note
+  linked_invoice_id:
+    type: string
+    description: If the type is credit_note, this field can be used to link the invoice that it refers to.


### PR DESCRIPTION
The invoice type will indicate if a given invoice is an actual
invoice or a credit note. If it is a credit note, the linked invoice id
will point to the related invoice.

https://vikingco.atlassian.net/browse/INT-4946